### PR TITLE
Fix and enable build for x86/x86_64

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,11 @@ jobs:
         . env.sh
         ./build.sh --all arm64-v8a
 
+    - name: "Build → x86"
+      run: |
+        . env.sh
+        ./build.sh --all x86
+
     - name: Archive
       run: |
         cd deps && zip -9r ../deps.zip -- *

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,11 @@ jobs:
         . env.sh
         ./build.sh --all x86
 
+    - name: "Build → x86_64"
+      run: |
+        . env.sh
+        ./build.sh --all x86_64
+
     - name: Archive
       run: |
         cd deps && zip -9r ../deps.zip -- *

--- a/build.sh
+++ b/build.sh
@@ -48,8 +48,6 @@ _setup_toolchain () {
 	elif [ "$TARGET_ABI" == x86_64 ]; then
 		API=21
 		CROSS_PREFIX=x86_64-linux-android
-		CFLAGS="-mssse3 -mfpmath=sse"
-		CXXFLAGS="-mssse3 -mfpmath=sse"
 	else
 		echo "Invalid ABI given"; return 1
 	fi

--- a/build.sh
+++ b/build.sh
@@ -34,26 +34,27 @@ _setup_toolchain () {
 	TARGET_ABI="$1"
 	if [ "$TARGET_ABI" == armeabi-v7a ]; then
 		API=16
-		CROSS_PREFIX=arm-linux-androideabi
-		export CC=armv7a-linux-androideabi$API-clang
-		export CXX=armv7a-linux-androideabi$API-clang++
+		CROSS_PREFIX=armv7a-linux-androideabi
 		CFLAGS="-mthumb"
 		CXXFLAGS="-mthumb"
 	elif [ "$TARGET_ABI" == arm64-v8a ]; then
 		API=21
 		CROSS_PREFIX=aarch64-linux-android
-		export CC=$CROSS_PREFIX$API-clang
-		export CXX=$CROSS_PREFIX$API-clang++
 	elif [ "$TARGET_ABI" == x86 ]; then
 		API=16
 		CROSS_PREFIX=i686-linux-android
-		export CC=$CROSS_PREFIX$API-clang
-		export CXX=$CROSS_PREFIX$API-clang++
+		CFLAGS="-mssse3 -mfpmath=sse"
+		CXXFLAGS="-mssse3 -mfpmath=sse"
+	elif [ "$TARGET_ABI" == x86_64 ]; then
+		API=21
+		CROSS_PREFIX=x86_64-linux-android
 		CFLAGS="-mssse3 -mfpmath=sse"
 		CXXFLAGS="-mssse3 -mfpmath=sse"
 	else
 		echo "Invalid ABI given"; return 1
 	fi
+	export CC=$CROSS_PREFIX$API-clang
+	export CXX=$CROSS_PREFIX$API-clang++
 	export AR=llvm-ar
 	export RANLIB=llvm-ranlib
 	export CFLAGS="-fPIC ${CFLAGS}"

--- a/scripts/Irrlicht.sh
+++ b/scripts/Irrlicht.sh
@@ -34,17 +34,8 @@ build () {
 	make
 
 	cp lib/Android/libIrrlichtMt.a $pkgdir/
+	cp $libpng $pkgdir/
+	cp $libjpeg $pkgdir/
 	cp -a $srcdir/irrlicht/include $pkgdir/include
 	cp -a $srcdir/irrlicht/media/Shaders $pkgdir/Shaders
-
-	# Integrate static dependencies directly into the Irrlicht library file
-	# (someone else can bother with a better solution sometime)
-	local libz=$(dirname $(which "$CC"))/../sysroot/usr/lib/$CROSS_PREFIX/libz.a
-	pushd $(mktemp -d)
-	for deplib in $libz $libpng $libjpeg; do
-		llvm-ar x "$deplib"
-		llvm-ar q $pkgdir/libIrrlichtMt.a *.o
-		rm -- *.o
-	done
-	popd
 }

--- a/scripts/Irrlicht.sh
+++ b/scripts/Irrlicht.sh
@@ -33,9 +33,7 @@ build () {
 		-DJPEG_INCLUDE_DIR=$(dirname "$libjpeg")/../include
 	make
 
-	cp lib/Android/libIrrlichtMt.a $pkgdir/
-	cp $libpng $pkgdir/
-	cp $libjpeg $pkgdir/
+	cp -p lib/Android/libIrrlichtMt.a $libpng $libjpeg $pkgdir/
 	cp -a $srcdir/irrlicht/include $pkgdir/include
 	cp -a $srcdir/irrlicht/media/Shaders $pkgdir/Shaders
 }

--- a/scripts/LuaJIT.sh
+++ b/scripts/LuaJIT.sh
@@ -16,7 +16,9 @@ download () {
 build () {
 	# Figure out needed host compiler
 	local hostcc="cc -m32"
-	[[ "$TARGET_ABI" == "arm64-"* ]] && hostcc="cc -m64"
+	if [[ "$TARGET_ABI" == "arm64-"* || "$TARGET_ABI" == x86_64 ]]; then
+		hostcc="cc -m64"
+	fi
 
 	cd $srcdir/LuaJIT/src
 	local targetcc="$CC $CFLAGS"


### PR DESCRIPTION
On x86 `local libz=$(dirname $(which "$CC"))/../sysroot/usr/lib/$CROSS_PREFIX/libz.a` picks the wrong zlib and the linker fails later. Let the linker pick the right zlib during the linking stage.
I've tested that it builds and works with the fix.